### PR TITLE
Edited 'pipeline' workflow to trigger on pull requests to master.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    pull_request:
+      branches: [master]
+      types: [opened, synchronize]
 
 jobs:
   install_build_test:


### PR DESCRIPTION
Edited 'pipeline' GH Actions workflow to trigger only on a pull request to master branch and will re-run whenever PR is opened or edited. Workflow no longer triggers on push to master. 